### PR TITLE
[CM-955] - Release application script.

### DIFF
--- a/release-application.sh
+++ b/release-application.sh
@@ -125,7 +125,8 @@ build_release_artifact() {
 
 # Deploy the released artifact to Nexus
 deploy_artifact() {
-    mvn deploy -Pfast-unsafe-build
+    # Skip tests - they were already ran in the build step
+    mvn deploy -P${BUILD_PROFILE} -DskipTests
 }
 
 # Update the scm state according to our release workflow.

--- a/release-application.sh
+++ b/release-application.sh
@@ -9,7 +9,6 @@
 set -e
 
 RELEASE_PROCESS_PROPERTIES="release-application.properties"
-MAVEN_PROPERTIES="target/maven-archiver/pom.properties"
 APPLICATION_PROPERTIES="src/main/resources/application.properties"
 APPLICATION_VERSION_PROPERTY="application_version"
 
@@ -58,13 +57,12 @@ extract_build_profile_var() {
 
 extract_application_versions() {
 
-    # Fast build the current application to be able the extract
-    # the version and update it to a proper release version
-    mvn package -Pfast-unsafe-build
+    # Extract the current application version
+    local CURRENT_VERSION=`printf 'APPLICATION_VERSION=${project.version}\n0\n' |\
+        mvn help:evaluate |\
+        grep '^APPLICATION_VERSION=' |\
+        sed -r 's/(^APPLICATION_VERSION=)(.+)(-SNAPSHOT|-RELEASE)/\2/'`
 
-    extract_property ${MAVEN_PROPERTIES} "version"
-
-    local CURRENT_VERSION=`echo ${PROPERTY_VALUE} | sed -r "s/(-SNAPSHOT|-RELEASE)//"`
     RELEASED_VERSION=${CURRENT_VERSION}-RELEASE
 
     # Extract the versions

--- a/release-application.sh
+++ b/release-application.sh
@@ -122,7 +122,7 @@ build_release_artifact() {
     git commit --amend -m "Released version: ${RELEASED_VERSION}."
 
     # Perform the build.
-    mvn clean install -P${BUILD_PROFILE} -DsnapshotsAllowed=true # TODO(cstan) must be set to false!!!
+    mvn clean install -P${BUILD_PROFILE} -DsnapshotsAllowed=false
 }
 
 # Deploy the released artifact to Nexus

--- a/release-application.sh
+++ b/release-application.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+# This script should behave like maven release plugin - merge the current working into master, make sure the version does not contain
+# any SNAPSHOT dependencies, perform the release, prepares the next iteration. It supports working in hotfix mode - where
+# a patched version is released.
+
+# Exit on any error to avoid troubles.
+# Print the statements before running them
+set -e
+
+RELEASE_PROCESS_PROPERTIES="release-application.properties"
+MAVEN_PROPERTIES="target/maven-archiver/pom.properties"
+APPLICATION_PROPERTIES="src/main/resources/application.properties"
+APPLICATION_VERSION_PROPERTY="application_version"
+
+extract_property() {
+    local PROPERTIES_FILE=$1
+    local PROPERTY_NAME=$2
+    PROPERTY_VALUE=`grep "^${PROPERTY_NAME}\s*=" "${PROPERTIES_FILE}" | sed "s/${PROPERTY_NAME}\s*=\s*//"`
+
+    if [ -z  ${PROPERTY_VALUE}  ]
+    then
+        echo "Could not found property '${PROPERTY_NAME}' in file '${PROPERTIES_FILE}'!"
+        exit 1
+    fi
+}
+
+extract_release_branch_var() {
+    extract_property ${RELEASE_PROCESS_PROPERTIES} "releaseBranch"
+    RELEASE_BRANCH_NAME=${PROPERTY_VALUE}
+}
+
+extract_is_hotfix_var() {
+    extract_property ${RELEASE_PROCESS_PROPERTIES} "hotfix"
+    if [ ${PROPERTY_VALUE} = "yes" ]
+    then
+        HOTFIX=1
+    else
+        HOTFIX=0
+    fi
+}
+
+extract_development_branch_var() {
+    extract_property ${RELEASE_PROCESS_PROPERTIES} "developmentBranch"
+    DEVELOPMENT_BRANCH_NAME=${PROPERTY_VALUE}
+
+    if [ ${HOTFIX} = 1 ]
+    then
+        extract_property ${RELEASE_PROCESS_PROPERTIES} "hotfixBranch"
+        DEVELOPMENT_BRANCH_NAME=${PROPERTY_VALUE}
+    fi
+}
+
+extract_build_profile_var() {
+    extract_property ${RELEASE_PROCESS_PROPERTIES} "buildProfile"
+    BUILD_PROFILE=${PROPERTY_VALUE}
+}
+
+extract_application_versions() {
+
+    # Fast build the current application to be able the extract
+    # the version and update it to a proper release version
+    mvn package -Pfast-unsafe-build
+
+    extract_property ${MAVEN_PROPERTIES} "version"
+
+    local CURRENT_VERSION=`echo ${PROPERTY_VALUE} | sed -r "s/(-SNAPSHOT|-RELEASE)//"`
+    RELEASED_VERSION=${CURRENT_VERSION}-RELEASE
+
+    # Extract the versions
+    local MAJOR=`echo ${CURRENT_VERSION} | sed -r 's/([0-9]+).([0-9]+).([0-9]+)/\1/'`
+    local MINOR=`echo ${CURRENT_VERSION} | sed -r 's/([0-9]+).([0-9]+).([0-9]+)/\2/'`
+    local PATCH=`echo ${CURRENT_VERSION} | sed -r 's/([0-9]+).([0-9]+).([0-9]+)/\3/'`
+
+    if [ ${HOTFIX} = 1 ]
+    then
+        RELEASED_VERSION="${MAJOR}.${MINOR}.$((PATCH+1))-RELEASE"
+    else
+        NEXT_VERSION="${MAJOR}.$((MINOR+1)).0-SNAPSHOT"
+    fi
+}
+
+update_version_in_application_properties() {
+    if [ -f ${APPLICATION_PROPERTIES} ]
+    then
+        sed -i.bak -r "s/^${APPLICATION_VERSION_PROPERTY}\s*=\s*.+/${APPLICATION_VERSION_PROPERTY} = $1/" ${APPLICATION_PROPERTIES}
+        rm -f ${APPLICATION_PROPERTIES}.bak
+        git add ${APPLICATION_PROPERTIES}
+    fi
+}
+
+update_current_version() {
+    local VERSION=$1
+    mvn versions:set -DnewVersion=${VERSION}
+    git add pom.xml
+
+    update_version_in_application_properties ${VERSION}
+}
+
+init_script_variables() {
+
+    extract_release_branch_var
+
+    extract_is_hotfix_var
+
+    extract_development_branch_var
+
+    extract_build_profile_var
+}
+
+# Build the release - we will make sure the tests are passing and the build is immutable and repeatable (no snapshots).
+build_release_artifact() {
+
+    # First merge the current development branch into release branch
+    git checkout ${RELEASE_BRANCH_NAME}
+    git merge --no-ff origin/${DEVELOPMENT_BRANCH_NAME} -m "M"
+
+    extract_application_versions
+
+    update_current_version ${RELEASED_VERSION}
+
+    git commit --amend -m "Released version: ${RELEASED_VERSION}."
+
+    # Perform the build.
+    mvn clean install -P${BUILD_PROFILE} -DsnapshotsAllowed=true # TODO(cstan) must be set to false!!!
+}
+
+# Deploy the released artifact to Nexus
+deploy_artifact() {
+    mvn deploy -Pfast-unsafe-build
+}
+
+# Update the scm state according to our release workflow.
+prepare_next_iteration() {
+
+    # Push the changes to remote.
+    git push origin "${RELEASE_BRANCH_NAME}"
+
+    # Create a tag of the current release so we will be able to easily perform hotfixes if needed from this point.
+    mvn scm:tag -Dtag="v${RELEASED_VERSION}"
+
+    # For hotfixes we won't do anything after the hotfix branch  was merged in the release.
+    if [ ${HOTFIX} = 0 ]
+    then
+        # Move the current development branch on top of the current release checkpoint.
+        git checkout ${DEVELOPMENT_BRANCH_NAME}
+        git rebase "v${RELEASED_VERSION}"
+
+        # Update the version of the application to the next snapshot - the start of a new iteration.
+        update_current_version ${NEXT_VERSION}
+        mvn scm:checkin -Dmessage="Init next development iteration: ${NEXT_VERSION}."
+    fi
+}
+
+### Perform the release
+perform_release() {
+    init_script_variables
+
+    build_release_artifact
+
+    deploy_artifact
+
+    prepare_next_iteration
+}
+
+perform_release
+################################
+

--- a/release-application.sh
+++ b/release-application.sh
@@ -6,7 +6,7 @@
 
 # Exit on any error to avoid troubles.
 # Print the statements before running them
-set -e
+set -ex
 
 RELEASE_PROCESS_PROPERTIES="release-application.properties"
 APPLICATION_PROPERTIES="src/main/resources/application.properties"


### PR DESCRIPTION
# Release process
In order to automate the release process of the applications that compose the Camversity project I created a script and I will explain here the development process that will enforce.

## Why
First of all - why performing releases? A good reason not to go only with snapshot versions for all the projects is to be able to precisely separate and identify the applications that runs in staging or production environment. This can be done while working in the meantime on new features and we will be able to very easily fix problems in productions without worrying that new developed features might broke things before they were thoroughly tested. 

## The development process updates 
A small change would need to be done on the current development process, and that is to create a development branch where all the features and not critical bugfixes are merged by the development teams, and to reserve the master branch or a separate release branch to only the released versions. 
When we are ready to release an application we just have to call the release-application.sh script.

## The release 
The release steps that are performed automatically:

* Merge the development branch in the release 
* Build the application with the correct version for release
* Deploy the release artifact in the internal repository
* Update the version for the next iteration and push the changes to the development branch
* Tag the release so we will be able to go back and perform hotfixes if needed

#### Versioning
The application version will be composed of MAJOR.MINOR.PATCH. At each release the minor will be increased and patch reset so if we release the application 1.3.1 the next iteration will be 1.4.0. 
If the application has an application.properties file (is a spring boot application) then the property application_version is also updated with the value found in the pom file. That lets us put a log very easy when the application starts so it will be very clear what is the version of the application (so we will know exactly what code runs in prod).

#### Hotfix support 
The release script has the support to perform hotfixes. When this happens the minor version is increased and we will need to manually rebase the current development branch on top of release branch after the hotfix was released to be able to integrate correctly the changes. 

#### Settings
Each application that enters the release cycle must have a simple property file where the following options are configured:
* developmentBranch - the  name of the branch where the development happens (ex: develop)
* releaseBranch - the name of the branch where the release are tagged (ex: master)
* buildProfile - maven profile used for building the application
* hotfix - boolean marking that the current release is a hotfix - default no.
* hotfixBranch - in the case of a hotfix the branch containing the fix that will be merged into the release branch. 